### PR TITLE
Update moya execution output

### DIFF
--- a/document_moya_podspec/after/execution_output.txt
+++ b/document_moya_podspec/after/execution_output.txt
@@ -3,10 +3,10 @@ Updating local specs repositories
 Analyzing dependencies
 Fetching podspec for `Moya` from `ROOT/tmp/document_moya_podspec`
 Downloading dependencies
-[32mInstalling Alamofire (3.1.5)[0m
+[32mInstalling Alamofire (3.2.1)[0m
 [32mInstalling Moya (5.2.1)[0m
 [32mInstalling ReactiveCocoa (4.0.0-RC.1)[0m
-[32mInstalling Result (1.0.1)[0m
+[32mInstalling Result (1.0.2)[0m
 [32mInstalling RxSwift (2.0.0-beta.4)[0m
 Generating Pods project
 Pod installation complete! There are 4 dependencies from the Podfile and 5 total pods installed.


### PR DESCRIPTION
Hi, 

I fixed the output for moya specs, causing https://github.com/realm/jazzy/pull/466 to fail.

Because master here is far behind, this is a PR to merge into "add-siesta" :( Perhaps after merging, we could make `master` here point to the newest state?