### PR TITLE
Update specs for #600: Fix abstract injection

### DIFF
--- a/misc_jazzy_features/after/docs/Classes/ClassWithInitializers.html
+++ b/misc_jazzy_features/after/docs/Classes/ClassWithInitializers.html
@@ -134,6 +134,8 @@
               </div>
             <p>Example extra abstract to inject before default abstract of ClassWithInitializers</p>
 
+<p>Class with initializers</p>
+
           </div>
         </section>
 

--- a/misc_jazzy_features/after/docs/Other Enums.html
+++ b/misc_jazzy_features/after/docs/Other Enums.html
@@ -129,6 +129,8 @@
 <p>Example header abstract content injection</p>
 </blockquote>
 
+<p>The following enums are available globally.</p>
+
           </div>
         </section>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Classes/ClassWithInitializers.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Classes/ClassWithInitializers.html
@@ -134,6 +134,8 @@
               </div>
             <p>Example extra abstract to inject before default abstract of ClassWithInitializers</p>
 
+<p>Class with initializers</p>
+
           </div>
         </section>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Enums.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Enums.html
@@ -129,6 +129,8 @@
 <p>Example header abstract content injection</p>
 </blockquote>
 
+<p>The following enums are available globally.</p>
+
           </div>
         </section>
 


### PR DESCRIPTION
This reverts https://github.com/realm/jazzy-integration-specs/commit/84836e5777c3c2588e204cb5bfaa099a94966290 and also updates the dependencies (as seen in the travis output from my jazzy PR)

This is for PR #601 (issue 600) on jazzy.
@jpsim: With this merged, I believe https://github.com/realm/jazzy/pull/601 would pass tests and thus could be merged, seeing as @agentk was keen on having this. (and on our side we still are!)
