### PR TITLE
Belated updates for realm/jazzy#697

### DIFF
--- a/document_siesta/after/api-docs/Classes/Resource.html
+++ b/document_siesta/after/api-docs/Classes/Resource.html
@@ -740,29 +740,6 @@ up to you to canonicalize your parameter order.</p>
 <p>Note that, unlike load() and loadIfNeeded(), this method does <em>not</em> update latestData or latestError,
 and does not notify resource observers about the result.</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter method: The HTTP verb to use for the request
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    <p>Parameter requestMutation:
-An optional callback to change details of the request before it is sent. For example:</p>
-<pre class="highlight plaintext"><code>request(.POST) { nsreq in
-  nsreq.HTTPBody = imageData
-  nsreq.addValue(
-    "image/png",
-    forHTTPHeaderField:
-      "Content-Type")
-}
-</code></pre>
-
-<p>Does nothing by default.</p>
-
-</div>
-
 <div class="aside aside-see-also">
     <p class="aside-title">See also</p>
     <p>SeeAlso:</p>
@@ -1465,18 +1442,6 @@ still exists.</p>
 <p>If the string cannot be encoded using the given encoding, this methods triggers the <code>onFailure(_:)</code> request hook
 immediately, without touching the network.</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter contentType: <code>text/plain</code> by default.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter encoding: UTF-8 (<code>NSUTF8StringEncoding</code>) by default.
-
-</div>
-
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>
@@ -1545,12 +1510,6 @@ immediately, without touching the network.</p>
 
 <p>If the <code>json</code> cannot be encoded as JSON, e.g. if it is a dictionary with non-JSON-convertible data, this methods
 triggers the <code>onFailure(_:)</code> request hook immediately, without touching the network.</p>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter contentType: <code>application/json</code> by default.
-
-</div>
 
                       </div>
                       <div class="declaration">

--- a/document_siesta/after/api-docs/Classes/Service.html
+++ b/document_siesta/after/api-docs/Classes/Service.html
@@ -270,31 +270,6 @@ configuration, and a “same URL → same resource” uniqueness guarantee.</p>
                       <div class="abstract">
                         <p>Creates a new service for the given API.</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter baseURL:
-The URL underneath which the API exposes its endpoints. If nil, there is no base URL, and thus you must use
-only <code><a href="../Classes/Service.html#/s:FC6Siesta7Service8resourceFT11absoluteURLGSqCSo5NSURL__CS_8Resource">resource(absoluteURL:)</a></code> to acquire resources.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter useDefaultTransformers:
-If true, include handling for JSON, text, and images. If false, leave all responses as <code>NSData</code> (unless you
-add your own <code><a href="../Protocols/ResponseTransformer.html">ResponseTransformer</a></code> using <code><a href="../Classes/Service.html#/s:FC6Siesta7Service9configureFTPS_31ConfigurationPatternConvertible_14requestMethodsGSqGSaOS_13RequestMethod__11descriptionGSqSS_10configurerFCVS_13Configuration7BuilderT__T_">configure(...)</a></code>).
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter networking:
-The handler to use for networking. The default is <code>NSURLSession</code> with ephemeral session configuration. You can
-pass an <code>NSURLSession</code>, <code>NSURLSessionConfiguration</code>, or <code>Alamofire.Manager</code> to use an existing provider with
-custom configuration. You can also use your own networking library of choice by implementing <code><a href="../Protocols/NetworkingProvider.html">NetworkingProvider</a></code>.
-
-</div>
-
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>
@@ -517,31 +492,6 @@ means that you will usually want to add your global configuration first, then re
 <p>If you want to provide global configuration, or if you need more fine-grained URL matching, use the other flavor
 of this method that takes a predicate as its first argument.</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter pattern:
-Selects the subset of resources to which this configuration applies. You can pass a <code>String</code>, <code><a href="../Classes/Resource.html">Resource</a></code>, or
-<code>NSRegularExpression</code> for the <code>pattern</code> argument — or write your own custom implementation of
-<code><a href="../Protocols/ConfigurationPatternConvertible.html">ConfigurationPatternConvertible</a></code>.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter description:
-An optional description of this piece of configuration, for logging and debugging purposes.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    <p>Parameter configurer:
-A closure that receives a mutable <code><a href="../Structs/Configuration.html">Configuration</a></code>, referenced as <code>$0.config</code>, which it may modify as it
-sees fit. This closure will be called whenever Siesta needs to generate or refresh configuration. You should
-not rely on it being called at any particular time, and should avoid making it cause side effects.</p>
-
-</div>
-
 <div class="aside aside-see-also">
     <p class="aside-title">See also</p>
     <p><code><a href="../Classes/Service.html#/s:FC6Siesta7Service9configureFT14whenURLMatchesFCSo5NSURLSb14requestMethodsGSqGSaOS_13RequestMethod__11descriptionGSqSS_10configurerFCVS_13Configuration7BuilderT__T_">configure(whenURLMatches:requestMethods:description:configurer:)</a></code>
@@ -646,13 +596,6 @@ for global config and more fine-grained matching</p>
 Use this if the wildcards in the <code>urlPattern</code> flavor of <code>configure()</code> aren’t robust enough.</p>
 
 <p>If you do not supply a predicate, then the configuration applies globally to all resources in this service.</p>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    <p>Parameter whenURLMatches:
-A predicate that matches absolute URLs of resources. The default is a predicate that matches anything.</p>
-
-</div>
 
 <div class="aside aside-see-also">
     <p class="aside-title">See also</p>

--- a/document_siesta/after/api-docs/Protocols/TypedContentAccessors.html
+++ b/document_siesta/after/api-docs/Protocols/TypedContentAccessors.html
@@ -303,13 +303,6 @@ For example, if you expect the content to be a UIImage:</p>
 <pre class="highlight plaintext"><code>let image = typedContent(ifNone: UIImage(named: "placeholder.png"))
 </code></pre>
 
-<div class="aside aside-returns">
-    <p class="aside-title">Returns</p>
-    <p>The content if it is present <em>and</em> can be downcast to a type matching both the <code>ifNone</code> parameter
-       and the inferred return type; otherwise returns <code>ifNone</code>.</p>
-
-</div>
-
 <div class="aside aside-see-also">
     <p class="aside-title">See also</p>
     <p><code><a href="../Protocols/TypedContentAccessors.html#/s:FE6SiestaPS_21TypedContentAccessors12typedContenturFT_GSqqd___">typedContent()</a></code></p>

--- a/document_siesta/after/api-docs/Structs/Entity.html
+++ b/document_siesta/after/api-docs/Structs/Entity.html
@@ -479,12 +479,6 @@ for example, you might see “<code>text/plain</code>”, “<code>text/plain; c
 
 <p>Entity does not support multi-valued headers (i.e. headers which occur more than once in the response).</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter key: The case-insensitive header name.
-
-</div>
-
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>

--- a/document_siesta/after/api-docs/Structs/ResponseContentTransformer.html
+++ b/document_siesta/after/api-docs/Structs/ResponseContentTransformer.html
@@ -273,31 +273,7 @@ error is passed on to the resource as is. Other failures are wrapped in a <code>
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter skipWhenEntityMatchesOutputType:
-When true, if the input content already matches <code>OutputContentType</code>, the transformer does nothing.
-When false, the tranformer always attempts to parse its input.
-Default is true.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter transformErrors:
-When true, apply the transformation to <code>Error.content</code> (if present).
-When false, only parse success responses.
-Default is false.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter processor:
-The transformation logic.
-
-</div>
-
+                        
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Classes/Resource.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Classes/Resource.html
@@ -740,29 +740,6 @@ up to you to canonicalize your parameter order.</p>
 <p>Note that, unlike load() and loadIfNeeded(), this method does <em>not</em> update latestData or latestError,
 and does not notify resource observers about the result.</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter method: The HTTP verb to use for the request
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    <p>Parameter requestMutation:
-An optional callback to change details of the request before it is sent. For example:</p>
-<pre class="highlight plaintext"><code>request(.POST) { nsreq in
-  nsreq.HTTPBody = imageData
-  nsreq.addValue(
-    "image/png",
-    forHTTPHeaderField:
-      "Content-Type")
-}
-</code></pre>
-
-<p>Does nothing by default.</p>
-
-</div>
-
 <div class="aside aside-see-also">
     <p class="aside-title">See also</p>
     <p>SeeAlso:</p>
@@ -1465,18 +1442,6 @@ still exists.</p>
 <p>If the string cannot be encoded using the given encoding, this methods triggers the <code>onFailure(_:)</code> request hook
 immediately, without touching the network.</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter contentType: <code>text/plain</code> by default.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter encoding: UTF-8 (<code>NSUTF8StringEncoding</code>) by default.
-
-</div>
-
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>
@@ -1545,12 +1510,6 @@ immediately, without touching the network.</p>
 
 <p>If the <code>json</code> cannot be encoded as JSON, e.g. if it is a dictionary with non-JSON-convertible data, this methods
 triggers the <code>onFailure(_:)</code> request hook immediately, without touching the network.</p>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter contentType: <code>application/json</code> by default.
-
-</div>
 
                       </div>
                       <div class="declaration">

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Classes/Service.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Classes/Service.html
@@ -270,31 +270,6 @@ configuration, and a “same URL → same resource” uniqueness guarantee.</p>
                       <div class="abstract">
                         <p>Creates a new service for the given API.</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter baseURL:
-The URL underneath which the API exposes its endpoints. If nil, there is no base URL, and thus you must use
-only <code><a href="../Classes/Service.html#/s:FC6Siesta7Service8resourceFT11absoluteURLGSqCSo5NSURL__CS_8Resource">resource(absoluteURL:)</a></code> to acquire resources.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter useDefaultTransformers:
-If true, include handling for JSON, text, and images. If false, leave all responses as <code>NSData</code> (unless you
-add your own <code><a href="../Protocols/ResponseTransformer.html">ResponseTransformer</a></code> using <code><a href="../Classes/Service.html#/s:FC6Siesta7Service9configureFTPS_31ConfigurationPatternConvertible_14requestMethodsGSqGSaOS_13RequestMethod__11descriptionGSqSS_10configurerFCVS_13Configuration7BuilderT__T_">configure(...)</a></code>).
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter networking:
-The handler to use for networking. The default is <code>NSURLSession</code> with ephemeral session configuration. You can
-pass an <code>NSURLSession</code>, <code>NSURLSessionConfiguration</code>, or <code>Alamofire.Manager</code> to use an existing provider with
-custom configuration. You can also use your own networking library of choice by implementing <code><a href="../Protocols/NetworkingProvider.html">NetworkingProvider</a></code>.
-
-</div>
-
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>
@@ -517,31 +492,6 @@ means that you will usually want to add your global configuration first, then re
 <p>If you want to provide global configuration, or if you need more fine-grained URL matching, use the other flavor
 of this method that takes a predicate as its first argument.</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter pattern:
-Selects the subset of resources to which this configuration applies. You can pass a <code>String</code>, <code><a href="../Classes/Resource.html">Resource</a></code>, or
-<code>NSRegularExpression</code> for the <code>pattern</code> argument — or write your own custom implementation of
-<code><a href="../Protocols/ConfigurationPatternConvertible.html">ConfigurationPatternConvertible</a></code>.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter description:
-An optional description of this piece of configuration, for logging and debugging purposes.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    <p>Parameter configurer:
-A closure that receives a mutable <code><a href="../Structs/Configuration.html">Configuration</a></code>, referenced as <code>$0.config</code>, which it may modify as it
-sees fit. This closure will be called whenever Siesta needs to generate or refresh configuration. You should
-not rely on it being called at any particular time, and should avoid making it cause side effects.</p>
-
-</div>
-
 <div class="aside aside-see-also">
     <p class="aside-title">See also</p>
     <p><code><a href="../Classes/Service.html#/s:FC6Siesta7Service9configureFT14whenURLMatchesFCSo5NSURLSb14requestMethodsGSqGSaOS_13RequestMethod__11descriptionGSqSS_10configurerFCVS_13Configuration7BuilderT__T_">configure(whenURLMatches:requestMethods:description:configurer:)</a></code>
@@ -646,13 +596,6 @@ for global config and more fine-grained matching</p>
 Use this if the wildcards in the <code>urlPattern</code> flavor of <code>configure()</code> aren’t robust enough.</p>
 
 <p>If you do not supply a predicate, then the configuration applies globally to all resources in this service.</p>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    <p>Parameter whenURLMatches:
-A predicate that matches absolute URLs of resources. The default is a predicate that matches anything.</p>
-
-</div>
 
 <div class="aside aside-see-also">
     <p class="aside-title">See also</p>

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Protocols/TypedContentAccessors.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Protocols/TypedContentAccessors.html
@@ -303,13 +303,6 @@ For example, if you expect the content to be a UIImage:</p>
 <pre class="highlight plaintext"><code>let image = typedContent(ifNone: UIImage(named: "placeholder.png"))
 </code></pre>
 
-<div class="aside aside-returns">
-    <p class="aside-title">Returns</p>
-    <p>The content if it is present <em>and</em> can be downcast to a type matching both the <code>ifNone</code> parameter
-       and the inferred return type; otherwise returns <code>ifNone</code>.</p>
-
-</div>
-
 <div class="aside aside-see-also">
     <p class="aside-title">See also</p>
     <p><code><a href="../Protocols/TypedContentAccessors.html#/s:FE6SiestaPS_21TypedContentAccessors12typedContenturFT_GSqqd___">typedContent()</a></code></p>

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Structs/Entity.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Structs/Entity.html
@@ -479,12 +479,6 @@ for example, you might see “<code>text/plain</code>”, “<code>text/plain; c
 
 <p>Entity does not support multi-valued headers (i.e. headers which occur more than once in the response).</p>
 
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter key: The case-insensitive header name.
-
-</div>
-
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Structs/ResponseContentTransformer.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Structs/ResponseContentTransformer.html
@@ -273,31 +273,7 @@ error is passed on to the resource as is. Other failures are wrapped in a <code>
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter skipWhenEntityMatchesOutputType:
-When true, if the input content already matches <code>OutputContentType</code>, the transformer does nothing.
-When false, the tranformer always attempts to parse its input.
-Default is true.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter transformErrors:
-When true, apply the transformation to <code>Error.content</code> (if present).
-When false, only parse success responses.
-Default is false.
-
-</div>
-
-<div class="aside aside-parameter">
-    <p class="aside-title">Parameter</p>
-    Parameter processor:
-The transformation logic.
-
-</div>
-
+                        
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>


### PR DESCRIPTION
The changes in realm/jazzy#697 removed duplicate asides for `Parameter[s]` and modified the content of the Siesta fixture, but did not update the integration spec — this PR updates that spec.

In this case, [Siesta’s `Parameter` callouts](https://github.com/bustoutsolutions/siesta/blob/e1a1790bf81a26063a8138647bfe19259db53fde/Source/Service.swift#L30-L40) are being removed as asides in the body, but still exist in the Parameters table (as expected):

![screen_shot_2017-01-09_at_3_21_36_am](https://cloud.githubusercontent.com/assets/1198851/21760547/fd42f488-d61a-11e6-8524-081771950b4d.png)