### PR TITLE
Support Section type for dash docsets in tests

### DIFF
--- a/document_alamofire/after/docs/Classes.html
+++ b/document_alamofire/after/docs/Classes.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Classes" class="dashAnchor"></a>
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/Enums.html
+++ b/document_alamofire/after/docs/Enums.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Enumerations" class="dashAnchor"></a>
     <a title="Enumerations  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/Extensions.html
+++ b/document_alamofire/after/docs/Extensions.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Extensions" class="dashAnchor"></a>
     <a title="Extensions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/Functions.html
+++ b/document_alamofire/after/docs/Functions.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Functions" class="dashAnchor"></a>
     <a title="Functions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/Protocols.html
+++ b/document_alamofire/after/docs/Protocols.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Protocols" class="dashAnchor"></a>
     <a title="Protocols  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/Structs.html
+++ b/document_alamofire/after/docs/Structs.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Structures" class="dashAnchor"></a>
     <a title="Structures  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/Typealiases.html
+++ b/document_alamofire/after/docs/Typealiases.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Type Aliases" class="dashAnchor"></a>
     <a title="Type Aliases  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Classes.html
+++ b/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Classes.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Classes" class="dashAnchor"></a>
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Enums.html
+++ b/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Enums.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Enumerations" class="dashAnchor"></a>
     <a title="Enumerations  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Extensions.html
+++ b/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Extensions.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Extensions" class="dashAnchor"></a>
     <a title="Extensions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Functions.html
+++ b/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Functions.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Functions" class="dashAnchor"></a>
     <a title="Functions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Protocols.html
+++ b/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Protocols.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Protocols" class="dashAnchor"></a>
     <a title="Protocols  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Structs.html
+++ b/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Structs.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Structures" class="dashAnchor"></a>
     <a title="Structures  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Typealiases.html
+++ b/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/Documents/Typealiases.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Type Aliases" class="dashAnchor"></a>
     <a title="Type Aliases  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/docSet.dsidx.csv
+++ b/document_alamofire/after/docs/docsets/Alamofire.docset/Contents/Resources/docSet.dsidx.csv
@@ -368,10 +368,10 @@ id,name,type,path
 367,ServerTrustPolicyManager,Class,Classes/ServerTrustPolicyManager.html
 368,NetworkReachabilityManager,Class,Classes/NetworkReachabilityManager.html
 369,TaskDelegate,Class,Classes/TaskDelegate.html
-370,Classes,,Classes.html
-371,Enumerations,,Enums.html
-372,Extensions,,Extensions.html
-373,Functions,,Functions.html
-374,Protocols,,Protocols.html
-375,Structures,,Structs.html
-376,"Type Aliases",,Typealiases.html
+370,Classes,Section,Classes.html
+371,Enumerations,Section,Enums.html
+372,Extensions,Section,Extensions.html
+373,Functions,Section,Functions.html
+374,Protocols,Section,Protocols.html
+375,Structures,Section,Structs.html
+376,"Type Aliases",Section,Typealiases.html

--- a/document_moya_podspec/after/docs/Classes.html
+++ b/document_moya_podspec/after/docs/Classes.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Classes" class="dashAnchor"></a>
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/Enums.html
+++ b/document_moya_podspec/after/docs/Enums.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Enumerations" class="dashAnchor"></a>
     <a title="Enumerations  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/Extensions.html
+++ b/document_moya_podspec/after/docs/Extensions.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Extensions" class="dashAnchor"></a>
     <a title="Extensions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/Functions.html
+++ b/document_moya_podspec/after/docs/Functions.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Functions" class="dashAnchor"></a>
     <a title="Functions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/Protocols.html
+++ b/document_moya_podspec/after/docs/Protocols.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Protocols" class="dashAnchor"></a>
     <a title="Protocols  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/Structs.html
+++ b/document_moya_podspec/after/docs/Structs.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Structures" class="dashAnchor"></a>
     <a title="Structures  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/Typealiases.html
+++ b/document_moya_podspec/after/docs/Typealiases.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Type Aliases" class="dashAnchor"></a>
     <a title="Type Aliases  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Classes.html
+++ b/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Classes.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Classes" class="dashAnchor"></a>
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Enums.html
+++ b/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Enums.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Enumerations" class="dashAnchor"></a>
     <a title="Enumerations  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Extensions.html
+++ b/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Extensions.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Extensions" class="dashAnchor"></a>
     <a title="Extensions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Functions.html
+++ b/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Functions.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Functions" class="dashAnchor"></a>
     <a title="Functions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Protocols.html
+++ b/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Protocols.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Protocols" class="dashAnchor"></a>
     <a title="Protocols  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Structs.html
+++ b/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Structs.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Structures" class="dashAnchor"></a>
     <a title="Structures  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Typealiases.html
+++ b/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/Documents/Typealiases.html
@@ -10,6 +10,7 @@
     
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Type Aliases" class="dashAnchor"></a>
     <a title="Type Aliases  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/docSet.dsidx.csv
+++ b/document_moya_podspec/after/docs/docsets/Moya.docset/Contents/Resources/docSet.dsidx.csv
@@ -189,10 +189,10 @@ id,name,type,path
 188,NetworkLoggerPlugin,Class,Classes/NetworkLoggerPlugin.html
 189,Response,Class,Classes/Response.html
 190,ReactiveSwiftMoyaProvider,Class,Classes/ReactiveSwiftMoyaProvider.html
-191,Classes,,Classes.html
-192,Enumerations,,Enums.html
-193,Extensions,,Extensions.html
-194,Functions,,Functions.html
-195,Protocols,,Protocols.html
-196,Structures,,Structs.html
-197,"Type Aliases",,Typealiases.html
+191,Classes,Section,Classes.html
+192,Enumerations,Section,Enums.html
+193,Extensions,Section,Extensions.html
+194,Functions,Section,Functions.html
+195,Protocols,Section,Protocols.html
+196,Structures,Section,Structs.html
+197,"Type Aliases",Section,Typealiases.html

--- a/document_realm_objc/after/docs/Categories.html
+++ b/document_realm_objc/after/docs/Categories.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Categories" class="dashAnchor"></a>
     <a title="Categories  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/Classes.html
+++ b/document_realm_objc/after/docs/Classes.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Classes" class="dashAnchor"></a>
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/Constants.html
+++ b/document_realm_objc/after/docs/Constants.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Constants" class="dashAnchor"></a>
     <a title="Constants  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/Enums.html
+++ b/document_realm_objc/after/docs/Enums.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Enumerations" class="dashAnchor"></a>
     <a title="Enumerations  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/Protocols.html
+++ b/document_realm_objc/after/docs/Protocols.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Protocols" class="dashAnchor"></a>
     <a title="Protocols  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/Type Definitions.html
+++ b/document_realm_objc/after/docs/Type Definitions.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Type Definitions" class="dashAnchor"></a>
     <a title="Type Definitions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Categories.html
+++ b/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Categories.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Categories" class="dashAnchor"></a>
     <a title="Categories  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Classes.html
+++ b/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Classes.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Classes" class="dashAnchor"></a>
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Constants.html
+++ b/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Constants.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Constants" class="dashAnchor"></a>
     <a title="Constants  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Enums.html
+++ b/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Enums.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Enumerations" class="dashAnchor"></a>
     <a title="Enumerations  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Protocols.html
+++ b/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Protocols.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Protocols" class="dashAnchor"></a>
     <a title="Protocols  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Type Definitions.html
+++ b/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/Documents/Type Definitions.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/objc/Section/Type Definitions" class="dashAnchor"></a>
     <a title="Type Definitions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/docSet.dsidx.csv
+++ b/document_realm_objc/after/docs/docsets/Realm.docset/Contents/Resources/docSet.dsidx.csv
@@ -432,9 +432,9 @@ id,name,type,path
 431,-rlmSync_clientResetBlock,Method,Categories/NSError(RLMSync).html#/c:objc(cs)NSError(im)rlmSync_clientResetBlock
 432,-rlmSync_clientResetBackedUpRealmPath,Method,Categories/NSError(RLMSync).html#/c:objc(cs)NSError(im)rlmSync_clientResetBackedUpRealmPath
 433,NSError(RLMSync),Extension,Categories/NSError(RLMSync).html
-434,Categories,,Categories.html
-435,Classes,,Classes.html
-436,Constants,,Constants.html
-437,Enumerations,,Enums.html
-438,Protocols,,Protocols.html
-439,"Type Definitions",,"Type Definitions.html"
+434,Categories,Section,Categories.html
+435,Classes,Section,Classes.html
+436,Constants,Section,Constants.html
+437,Enumerations,Section,Enums.html
+438,Protocols,Section,Protocols.html
+439,"Type Definitions",Section,"Type Definitions.html"

--- a/document_realm_swift/after/docs/Classes.html
+++ b/document_realm_swift/after/docs/Classes.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Classes" class="dashAnchor"></a>
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/Enums.html
+++ b/document_realm_swift/after/docs/Enums.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Enumerations" class="dashAnchor"></a>
     <a title="Enumerations  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/Extensions.html
+++ b/document_realm_swift/after/docs/Extensions.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Extensions" class="dashAnchor"></a>
     <a title="Extensions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/Functions.html
+++ b/document_realm_swift/after/docs/Functions.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Functions" class="dashAnchor"></a>
     <a title="Functions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/Protocols.html
+++ b/document_realm_swift/after/docs/Protocols.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Protocols" class="dashAnchor"></a>
     <a title="Protocols  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/Structs.html
+++ b/document_realm_swift/after/docs/Structs.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Structures" class="dashAnchor"></a>
     <a title="Structures  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/Typealiases.html
+++ b/document_realm_swift/after/docs/Typealiases.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Type Aliases" class="dashAnchor"></a>
     <a title="Type Aliases  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Classes.html
+++ b/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Classes.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Classes" class="dashAnchor"></a>
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Enums.html
+++ b/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Enums.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Enumerations" class="dashAnchor"></a>
     <a title="Enumerations  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Extensions.html
+++ b/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Extensions.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Extensions" class="dashAnchor"></a>
     <a title="Extensions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Functions.html
+++ b/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Functions.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Functions" class="dashAnchor"></a>
     <a title="Functions  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Protocols.html
+++ b/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Protocols.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Protocols" class="dashAnchor"></a>
     <a title="Protocols  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Structs.html
+++ b/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Structs.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Structures" class="dashAnchor"></a>
     <a title="Structures  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Typealiases.html
+++ b/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/Documents/Typealiases.html
@@ -27,6 +27,7 @@
 
   </head>
   <body>
+    <a name="//apple_ref/swift/Section/Type Aliases" class="dashAnchor"></a>
     <a title="Type Aliases  Reference"></a>
     <header>
       <div class="content-wrapper">

--- a/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/docSet.dsidx.csv
+++ b/document_realm_swift/after/docs/docsets/RealmSwift.docset/Contents/Resources/docSet.dsidx.csv
@@ -394,10 +394,10 @@ id,name,type,path
 393,SyncPermissionOffer,Class,Classes/SyncPermissionOffer.html
 394,SyncPermissionOfferResponse,Class,Classes/SyncPermissionOfferResponse.html
 395,ThreadSafeReference,Class,Classes/ThreadSafeReference.html
-396,Classes,,Classes.html
-397,Enumerations,,Enums.html
-398,Extensions,,Extensions.html
-399,Functions,,Functions.html
-400,Protocols,,Protocols.html
-401,Structures,,Structs.html
-402,"Type Aliases",,Typealiases.html
+396,Classes,Section,Classes.html
+397,Enumerations,Section,Enums.html
+398,Extensions,Section,Extensions.html
+399,Functions,Section,Functions.html
+400,Protocols,Section,Protocols.html
+401,Structures,Section,Structs.html
+402,"Type Aliases",Section,Typealiases.html

--- a/document_siesta/after/api-docs/Caching.html
+++ b/document_siesta/after/api-docs/Caching.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Caching" class="dashAnchor"></a>
 
     <a title="Caching  Reference"></a>
 

--- a/document_siesta/after/api-docs/Logging.html
+++ b/document_siesta/after/api-docs/Logging.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Logging" class="dashAnchor"></a>
 
     <a title="Logging  Reference"></a>
 

--- a/document_siesta/after/api-docs/Network Layer.html
+++ b/document_siesta/after/api-docs/Network Layer.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Network Layer" class="dashAnchor"></a>
 
     <a title="Network Layer  Reference"></a>
 

--- a/document_siesta/after/api-docs/Observing Resources.html
+++ b/document_siesta/after/api-docs/Observing Resources.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Observing Resources" class="dashAnchor"></a>
 
     <a title="Observing Resources  Reference"></a>
 

--- a/document_siesta/after/api-docs/Other Extensions.html
+++ b/document_siesta/after/api-docs/Other Extensions.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Extensions" class="dashAnchor"></a>
 
     <a title="Other Extensions  Reference"></a>
 

--- a/document_siesta/after/api-docs/Other Protocols.html
+++ b/document_siesta/after/api-docs/Other Protocols.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Protocols" class="dashAnchor"></a>
 
     <a title="Other Protocols  Reference"></a>
 

--- a/document_siesta/after/api-docs/Other Structs.html
+++ b/document_siesta/after/api-docs/Other Structs.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Structures" class="dashAnchor"></a>
 
     <a title="Other Structures  Reference"></a>
 

--- a/document_siesta/after/api-docs/Requests.html
+++ b/document_siesta/after/api-docs/Requests.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Requests" class="dashAnchor"></a>
 
     <a title="Requests  Reference"></a>
 

--- a/document_siesta/after/api-docs/Resources.html
+++ b/document_siesta/after/api-docs/Resources.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Resources" class="dashAnchor"></a>
 
     <a title="Resources  Reference"></a>
 

--- a/document_siesta/after/api-docs/Response Pipeline.html
+++ b/document_siesta/after/api-docs/Response Pipeline.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Response Pipeline" class="dashAnchor"></a>
 
     <a title="Response Pipeline  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Caching.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Caching.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Caching" class="dashAnchor"></a>
 
     <a title="Caching  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Logging.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Logging.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Logging" class="dashAnchor"></a>
 
     <a title="Logging  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Network Layer.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Network Layer.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Network Layer" class="dashAnchor"></a>
 
     <a title="Network Layer  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Observing Resources.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Observing Resources.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Observing Resources" class="dashAnchor"></a>
 
     <a title="Observing Resources  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Other Extensions.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Other Extensions.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Extensions" class="dashAnchor"></a>
 
     <a title="Other Extensions  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Other Protocols.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Other Protocols.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Protocols" class="dashAnchor"></a>
 
     <a title="Other Protocols  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Other Structs.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Other Structs.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Structures" class="dashAnchor"></a>
 
     <a title="Other Structures  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Requests.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Requests.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Requests" class="dashAnchor"></a>
 
     <a title="Requests  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Resources.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Resources.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Resources" class="dashAnchor"></a>
 
     <a title="Resources  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Response Pipeline.html
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/Documents/Response Pipeline.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Response Pipeline" class="dashAnchor"></a>
 
     <a title="Response Pipeline  Reference"></a>
 

--- a/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/docSet.dsidx.csv
+++ b/document_siesta/after/api-docs/docsets/Siesta.docset/Contents/Resources/docSet.dsidx.csv
@@ -262,13 +262,13 @@ id,name,type,path
 261,Configuration,Struct,Structs/Configuration.html
 262,ConfigurationPatternConvertible,Protocol,Protocols/ConfigurationPatternConvertible.html
 263,TypedContentAccessors,Protocol,Protocols/TypedContentAccessors.html
-264,Resources,,Resources.html
-265,"Observing Resources",,"Observing Resources.html"
-266,Requests,,Requests.html
-267,"Response Pipeline",,"Response Pipeline.html"
-268,Caching,,Caching.html
-269,"Network Layer",,"Network Layer.html"
-270,Logging,,Logging.html
-271,"Other Extensions",,"Other Extensions.html"
-272,"Other Protocols",,"Other Protocols.html"
-273,"Other Structures",,"Other Structs.html"
+264,Resources,Section,Resources.html
+265,"Observing Resources",Section,"Observing Resources.html"
+266,Requests,Section,Requests.html
+267,"Response Pipeline",Section,"Response Pipeline.html"
+268,Caching,Section,Caching.html
+269,"Network Layer",Section,"Network Layer.html"
+270,Logging,Section,Logging.html
+271,"Other Extensions",Section,"Other Extensions.html"
+272,"Other Protocols",Section,"Other Protocols.html"
+273,"Other Structures",Section,"Other Structs.html"

--- a/misc_jazzy_features/after/docs/Guides.html
+++ b/misc_jazzy_features/after/docs/Guides.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Guides" class="dashAnchor"></a>
 
     <a title="Guides  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/Other Classes.html
+++ b/misc_jazzy_features/after/docs/Other Classes.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Classes" class="dashAnchor"></a>
 
     <a title="Other Classes  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/Other Enums.html
+++ b/misc_jazzy_features/after/docs/Other Enums.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Enumerations" class="dashAnchor"></a>
 
     <a title="Other Enumerations  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/Other Extensions.html
+++ b/misc_jazzy_features/after/docs/Other Extensions.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Extensions" class="dashAnchor"></a>
 
     <a title="Other Extensions  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/Other Functions.html
+++ b/misc_jazzy_features/after/docs/Other Functions.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Functions" class="dashAnchor"></a>
 
     <a title="Other Functions  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/Other Global Variables.html
+++ b/misc_jazzy_features/after/docs/Other Global Variables.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Global Variables" class="dashAnchor"></a>
 
     <a title="Other Global Variables  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/Other Structs.html
+++ b/misc_jazzy_features/after/docs/Other Structs.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Structures" class="dashAnchor"></a>
 
     <a title="Other Structures  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/Yang.html
+++ b/misc_jazzy_features/after/docs/Yang.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Yang" class="dashAnchor"></a>
 
     <a title="Yang  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/Yin.html
+++ b/misc_jazzy_features/after/docs/Yin.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Yin" class="dashAnchor"></a>
 
     <a title="Yin  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Guides.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Guides.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Guides" class="dashAnchor"></a>
 
     <a title="Guides  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Classes.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Classes.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Classes" class="dashAnchor"></a>
 
     <a title="Other Classes  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Enums.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Enums.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Enumerations" class="dashAnchor"></a>
 
     <a title="Other Enumerations  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Extensions.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Extensions.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Extensions" class="dashAnchor"></a>
 
     <a title="Other Extensions  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Functions.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Functions.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Functions" class="dashAnchor"></a>
 
     <a title="Other Functions  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Global Variables.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Global Variables.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Global Variables" class="dashAnchor"></a>
 
     <a title="Other Global Variables  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Structs.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Other Structs.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Other Structures" class="dashAnchor"></a>
 
     <a title="Other Structures  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Yang.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Yang.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Yang" class="dashAnchor"></a>
 
     <a title="Yang  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Yin.html
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/Documents/Yin.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/swift/Section/Yin" class="dashAnchor"></a>
 
     <a title="Yin  Reference"></a>
 

--- a/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/docSet.dsidx.csv
+++ b/misc_jazzy_features/after/docs/docsets/MiscJazzyFeatures.docset/Contents/Resources/docSet.dsidx.csv
@@ -48,12 +48,12 @@ id,name,type,path
 47,documentedGlobal,Global,Yin.html#/s:17MiscJazzyFeatures16documentedGlobalSbv
 48,"Example 1",Guide,example-1.html
 49,"Example 2",Guide,example-2.html
-50,Guides,,Guides.html
-51,Yin,,Yin.html
-52,Yang,,Yang.html
-53,"Other Classes",,"Other Classes.html"
-54,"Other Global Variables",,"Other Global Variables.html"
-55,"Other Enumerations",,"Other Enums.html"
-56,"Other Extensions",,"Other Extensions.html"
-57,"Other Functions",,"Other Functions.html"
-58,"Other Structures",,"Other Structs.html"
+50,Guides,Section,Guides.html
+51,Yin,Section,Yin.html
+52,Yang,Section,Yang.html
+53,"Other Classes",Section,"Other Classes.html"
+54,"Other Global Variables",Section,"Other Global Variables.html"
+55,"Other Enumerations",Section,"Other Enums.html"
+56,"Other Extensions",Section,"Other Extensions.html"
+57,"Other Functions",Section,"Other Functions.html"
+58,"Other Structures",Section,"Other Structs.html"

--- a/misc_jazzy_objc_features/after/docs/Other Categories.html
+++ b/misc_jazzy_objc_features/after/docs/Other Categories.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Other Categories" class="dashAnchor"></a>
 
     <a title="Other Categories  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/Other Classes.html
+++ b/misc_jazzy_objc_features/after/docs/Other Classes.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Other Classes" class="dashAnchor"></a>
 
     <a title="Other Classes  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/Other Constants.html
+++ b/misc_jazzy_objc_features/after/docs/Other Constants.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Other Constants" class="dashAnchor"></a>
 
     <a title="Other Constants  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/Other Enums.html
+++ b/misc_jazzy_objc_features/after/docs/Other Enums.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Other Enumerations" class="dashAnchor"></a>
 
     <a title="Other Enumerations  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/Ying.html
+++ b/misc_jazzy_objc_features/after/docs/Ying.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Ying" class="dashAnchor"></a>
 
     <a title="Ying  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Other Categories.html
+++ b/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Other Categories.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Other Categories" class="dashAnchor"></a>
 
     <a title="Other Categories  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Other Classes.html
+++ b/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Other Classes.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Other Classes" class="dashAnchor"></a>
 
     <a title="Other Classes  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Other Constants.html
+++ b/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Other Constants.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Other Constants" class="dashAnchor"></a>
 
     <a title="Other Constants  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Other Enums.html
+++ b/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Other Enums.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Other Enumerations" class="dashAnchor"></a>
 
     <a title="Other Enumerations  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Ying.html
+++ b/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/Documents/Ying.html
@@ -14,6 +14,7 @@
   </head>
   <body>
 
+    <a name="//apple_ref/objc/Section/Ying" class="dashAnchor"></a>
 
     <a title="Ying  Reference"></a>
 

--- a/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/docSet.dsidx.csv
+++ b/misc_jazzy_objc_features/after/docs/docsets/JazzyKit.docset/Contents/Resources/docSet.dsidx.csv
@@ -17,8 +17,8 @@ id,name,type,path
 16,-categoryMethod:,Method,Classes/ObjCTopLevelClass.html#/c:objc(cs)ObjCTopLevelClass(im)categoryMethod:
 17,-markedCategoryMethod:,Method,Classes/ObjCTopLevelClass.html#/c:objc(cs)ObjCTopLevelClass(im)markedCategoryMethod:
 18,ObjCTopLevelClass,Class,Classes/ObjCTopLevelClass.html
-19,Ying,,Ying.html
-20,"Other Categories",,"Other Categories.html"
-21,"Other Classes",,"Other Classes.html"
-22,"Other Constants",,"Other Constants.html"
-23,"Other Enumerations",,"Other Enums.html"
+19,Ying,Section,Ying.html
+20,"Other Categories",Section,"Other Categories.html"
+21,"Other Classes",Section,"Other Classes.html"
+22,"Other Constants",Section,"Other Constants.html"
+23,"Other Enumerations",Section,"Other Enums.html"


### PR DESCRIPTION
I did this to support a pull request I worked up in jazzy that adds type
information for Overview items so that they are recognized at a Section
type in the Dash docset index generation process. That change is
necessary because Dash requires that the index have types for everything
in the index.

All of the docSet.dsidx.csv changes I am confident are correct and
should be there. The apple_ref anchors on the other hand is something I
am not super familiar with. The addition of them hasn't seemed to break
anything as far as I can tell. Also, based on my very brief
understanding of the apple_ref anchors it seems that they should have
been there all along. If that is not the case please enlighten me as to
how it is supposed to work and why, and I will dig in and try and get it
there.

This is paired with https://github.com/realm/jazzy/pull/951