### PR TITLE
Stop using git:// submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/Alamofire/Alamofire.git
 [submodule "document_moya_podspec/before"]
 	path = document_moya_podspec/before
-	url = git://github.com/ashfurrow/Moya.git
+	url = https://github.com/ashfurrow/Moya.git
 [submodule "document_realm_swift/before"]
 	path = document_realm_swift/before
 	url = https://github.com/realm/realm-cocoa.git


### PR DESCRIPTION
GitHub actions' macOS image has upgraded to a version of git that requires this.